### PR TITLE
Implement automatic network connection

### DIFF
--- a/apps/nerves_uccd/config/config.exs
+++ b/apps/nerves_uccd/config/config.exs
@@ -4,7 +4,6 @@ config :uca_lib, Registration,
   jid: "user_1@localhost",
   password: "pass_1",
   host: "192.168.0.1",
-  # host: "localhost",
   device_type: "Player",
   device_version: 1
 
@@ -13,17 +12,13 @@ config :nerves_uccd, Networking,
 
   # types: :ethernet, :wireless
   type: :ethernet,
-  # modes: :static, :dynamic
-  mode: :static,
-  # opts for :ethernet type and :dynamic mode:
+  # opts for :ethernet type and DHCP
   #  [interface: :eth0]
-  # opts for :ethernet type and :static mode: interface:
-  #  [:eth0, ip: "192.168.0.1", mask: "16"]
-  # opts for :wireless type and :dynamic mode:
-  #   [interface: "wlan0", ssid: "my_net", key_mgmt: :"WPA-PSK", psk: "pass"]
-  # opts for :wireless type and :static mode: interface:
-  #   [interface: "wlan0", ip: "192.168.0.1", ssid: "my_net", key_mgmt: :"WPA-PSK", psk: "pass"]
-  opts: [interface: :eth0, ip: "192.168.0.100", mask: "16"]
+  # opts for :ethernet type and fixed IP address
+  #  [interface: :eth0, ip: "192.168.0.100"]
+  # opts for :wireless type and DHCP
+  #  [interface: :wlan0, ssid: "my_net", psk: "pass", key_mgmt: :"WPA-PSK"]
+  opts: [interface: :eth0]
 
 config :erl_sshd,
   app: :nerves_uccd,

--- a/apps/nerves_uccd/lib/nerves_uccd/application.ex
+++ b/apps/nerves_uccd/lib/nerves_uccd/application.ex
@@ -1,8 +1,6 @@
 defmodule NervesUccd.Application do
   use Application
 
-  alias UcaLib.{Discovery, Registration}
-
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
@@ -11,5 +9,4 @@ defmodule NervesUccd.Application do
     opts = [strategy: :one_for_one, name: NervesUccd.Supervisor]
     Supervisor.start_link(children, opts)
   end
-
 end

--- a/apps/nerves_uccd/lib/nerves_uccd/worker.ex
+++ b/apps/nerves_uccd/lib/nerves_uccd/worker.ex
@@ -8,7 +8,9 @@ defmodule NervesUccd.Worker do
 
   require Logger
 
-  def start_link(), do: GenServer.start_link(__MODULE__, nil, [name: @name])
+  def start_link() do
+    GenServer.start_link(__MODULE__, nil, [name: @name])
+  end
 
   def init(_) do
     GenServer.cast(@name, :setup_networking)
@@ -16,15 +18,13 @@ defmodule NervesUccd.Worker do
   end
 
   def handle_cast(:setup_networking, state) do
-    :ok = Networking.setup
-    GenServer.cast(@name, :setup_uca)
+    {:ok, _pid} = Networking.start_link(self())
     {:noreply, state}
   end
 
-  def handle_cast(:setup_uca, state) do
+  def handle_info(:setup_uca, state) do
     {:ok, pid} = Registration.connect
     :ok = Discovery.activate pid
     {:noreply, state}
   end
-
 end

--- a/apps/nerves_uccd/mix.exs
+++ b/apps/nerves_uccd/mix.exs
@@ -67,8 +67,8 @@ defmodule NervesUccd.Mixfile do
 
   defp mim_iot_deps() do
     [{:nerves_runtime, "~> 0.1.0"},
-     # {:nerves_interim_wifi, "~> 0.2"},
-     {:nerves_networking, "~> 0.6"},
+     {:nerves_network_interface, "~> 0.4.0"},
+     {:nerves_interim_wifi, "~> 0.2"},
      {:erl_sshd, github: "ivanos/erl_sshd"}]
   end
 

--- a/apps/uca_lib/lib/uca_lib/registration.ex
+++ b/apps/uca_lib/lib/uca_lib/registration.ex
@@ -3,8 +3,6 @@ defmodule UcaLib.Registration do
   This module implements the Registration step from the UDA 2.0
   """
 
-  @connect_config Application.get_env :uca_lib, Registration
-
   @type device_jid :: String.t
   @type device_resource :: String.t
 
@@ -47,18 +45,22 @@ defmodule UcaLib.Registration do
 
   # Internals
 
+  defp get_connect_config() do
+    Application.get_env :uca_lib, Registration
+  end
+
   defp connect_opts(opts) do
-    Keyword.merge [{:resource, resource()} | @connect_config], opts
+    config = get_connect_config()
+    Keyword.merge [{:resource, resource(config)} | config], opts
   end
 
   # TODO: Appropriately form an XMPP resource
   # See C.5.4 Binding Devices and Control Points as a Resource in UDA 2.0
-  defp resource() do
-    device_type = @connect_config[:device_type]
-    device_version = @connect_config[:device_version]
+  defp resource(config) do
+    device_type = config[:device_type]
+    device_version = config[:device_version]
     "urn:schemas-upnp-org:device:#{device_type}:#{device_version}:#{uuid()}"
   end
 
   defp uuid(), do: UUID.uuid4()
-
 end

--- a/apps/uca_lib/lib/uca_lib/worker.ex
+++ b/apps/uca_lib/lib/uca_lib/worker.ex
@@ -141,7 +141,7 @@ defmodule UcaLib.Worker do
 
   def handle_cast({:connect, args}, %State{conn_pid: nil} = state) do
     {:ok, pid} = Conn.start_link args
-    Logger.info "Conecting as #{state.full_jid}"
+    Logger.info "Connecting as #{state.full_jid} with args #{inspect args}"
     {:noreply, %{state | conn_pid: pid}}
   end
 


### PR DESCRIPTION
This PR implements automatic network connection for:

* Ethernet connection with fixed IP address
* Ethernet connection with DHCP
* Wireless connection with DHCP

It uses Nerves.NetworkInterface and Nerves.Udhcpc events to listen for network changes and configures the UcaLib discovery mechanism. It also removes Nerves.Networking because it's not used anymore.